### PR TITLE
Added the fail_if_empty configuration flag such that another module c…

### DIFF
--- a/docs/smartattributes.md
+++ b/docs/smartattributes.md
@@ -27,6 +27,7 @@ The filter has the following configuration options:
 * `id_attribute`. A string to use as the name of the newly added attribute. Defaults to `smart_id`.
 * `add_authority`. A boolean to indicate whether or not to append the SAML AuthenticatingAuthority to the resulting identifier. This can be useful to indicate what SAML IdP was used, in case the original identifier is not scoped. Defaults to `TRUE`.
 * `add_candidate`. A boolean to indicate whether or not to prepend the candidate attribute name to the resulting identifier. This can be useful to indicate the attribute originating the identifier. Defaults to `TRUE`.
+* `fail_if_empty`. A boolean to indicate whether this module reports a failure if no suitable identifier attribute could be found. Set this to `FALSE` if a missing identifier attribute should be handled at a later step in the AuthProc filter queue. Defaults to `TRUE`.
 
 The generated identifiers have the following form:
 

--- a/lib/Auth/Process/SmartID.php
+++ b/lib/Auth/Process/SmartID.php
@@ -45,6 +45,10 @@ class SmartID extends \SimpleSAML\Auth\ProcessingFilter
      */
     private $add_candidate = true;
 
+    /**
+     * Whether a missing identifier is o.k.
+     */
+    private $fail_if_empty = true;
 
     /**
      * @param array $config
@@ -84,6 +88,13 @@ class SmartID extends \SimpleSAML\Auth\ProcessingFilter
                 throw new \Exception('SmartID authproc configuration error: \'add_candidate\' should be a boolean.');
             }
         }
+
+	if (array_key_exists('fail_if_empty', $config)) {
+	    $this->fail_if_empty = $config['fail_if_empty'];
+            if (!is_bool($this->fail_if_empty)) {
+               throw new Exception('SmartID authproc configuration error: \'fail_if_empty\' should be a boolean.');
+            }
+        }
     }
 
 
@@ -109,10 +120,16 @@ class SmartID extends \SimpleSAML\Auth\ProcessingFilter
         /*
          * At this stage no usable id_candidate has been detected.
          */
-        throw new \SimpleSAML\Error\Exception('This service needs at least one of the following
+	if ($this->fail_if_empty) {
+	     throw new \SimpleSAML\Error\Exception('This service needs at least one of the following
             attributes to identity users: '.implode(', ', $this->candidates).'. Unfortunately not
             one of them was detected. Please ask your institution administrator to release one of
             them, or try using another identity provider.');
+        } else {
+	    // return an empty identifier, missing id attribute must be handled
+	    // by another authproc filter
+            return ''; 
+	}
     }
 
 

--- a/lib/Auth/Process/SmartID.php
+++ b/lib/Auth/Process/SmartID.php
@@ -120,16 +120,18 @@ class SmartID extends \SimpleSAML\Auth\ProcessingFilter
         /*
          * At this stage no usable id_candidate has been detected.
          */
-	if ($this->fail_if_empty) {
-	     throw new \SimpleSAML\Error\Exception('This service needs at least one of the following
-            attributes to identity users: '.implode(', ', $this->candidates).'. Unfortunately not
-            one of them was detected. Please ask your institution administrator to release one of
-            them, or try using another identity provider.');
+        if ($this->fail_if_empty) {
+            throw new \SimpleSAML\Error\Exception('This service needs at least one of the following 
+                attributes to identity users: '.implode(', ', $this->candidates).'. Unfortunately not
+                one of them was detected. Please ask your institution administrator to release one of
+                them, or try using another identity provider.');
         } else {
-	    // return an empty identifier, missing id attribute must be handled
-	    // by another authproc filter
+        /*
+         * Return an empty identifier, 
+         * missing id attribute must be handled by another authproc filter
+         */
             return ''; 
-	}
+        }
     }
 
 

--- a/lib/Auth/Process/SmartID.php
+++ b/lib/Auth/Process/SmartID.php
@@ -117,7 +117,8 @@ class SmartID extends \SimpleSAML\Auth\ProcessingFilter
                 }
             }
         }
-        /*
+
+        /**
          * At this stage no usable id_candidate has been detected.
          */
         if ($this->fail_if_empty) {
@@ -126,10 +127,10 @@ class SmartID extends \SimpleSAML\Auth\ProcessingFilter
                 one of them was detected. Please ask your institution administrator to release one of
                 them, or try using another identity provider.');
         } else {
-        /*
-         * Return an empty identifier, 
-         * missing id attribute must be handled by another authproc filter
-         */
+            /**
+             * Return an empty identifier, 
+             * missing id attribute must be handled by another authproc filter
+             */
             return ''; 
         }
     }


### PR DESCRIPTION
…an handle a missing identifier attribute

This module used to fail with a user-visible error if no ID could be found. I added a config flag, defaulting to the old behaviour (fail), which can be set to fail_if_empty=false, which allows this module to return silently and leave the missing ID to another module in the authproc chain. 

Please consider this new feature for inclusion in this module's code.