### PR TITLE
When multiple AuthenticatingAuthority elements are present, use the last

### DIFF
--- a/docs/smartattributes.md
+++ b/docs/smartattributes.md
@@ -25,7 +25,7 @@ The filter has the following configuration options:
 	* windowslive_targetedID
 	* linkedin_targetedID
 * `id_attribute`. A string to use as the name of the newly added attribute. Defaults to `smart_id`.
-* `add_authority`. A boolean to indicate whether or not to append the SAML AuthenticatingAuthority to the resulting identifier. This can be useful to indicate what SAML IdP was used, in case the original identifier is not scoped. Defaults to `TRUE`.
+* `add_authority`. A boolean to indicate whether or not to append the SAML AuthenticatingAuthority to the resulting identifier. This can be useful to indicate what SAML IdP was used, in case the original identifier is not scoped. When multiple values are in the AuthenticatingAuthority element, the last (closest to us) will be used. Defaults to `TRUE`.
 * `add_candidate`. A boolean to indicate whether or not to prepend the candidate attribute name to the resulting identifier. This can be useful to indicate the attribute originating the identifier. Defaults to `TRUE`.
 * `fail_if_empty`. A boolean to indicate whether this module reports a failure if no suitable identifier attribute could be found. Set this to `FALSE` if a missing identifier attribute should be handled at a later step in the AuthProc filter queue. Defaults to `TRUE`.
 

--- a/docs/smartattributes.md
+++ b/docs/smartattributes.md
@@ -4,10 +4,8 @@ SmartAttributes module
 The SmartAttributes module provides authentication processing filters to add attributes.
 The logic in this filter exceeds what is possible with the standard filters such, as [`core:AttributeAdd`], [`core:AttributeAlter`], and [`core:AttributeMap`].
 
-
-
 `smartattributes:SmartID`
-=========================
+-------------------------
 
 A filter to add an identifier attribute, based on the first non-empty attribute from a given list of attribute names.
 This is useful when there are multiple SAML IdPs configured, and there is no common identifier among them.
@@ -15,15 +13,15 @@ For example some IdPs send eduPersonPrincipalName, while others send eduPersonTa
 The filter has the following configuration options:
 
 * `candidates`. An array of attributes names to consider as the identifier attribute. Defaults to:
-	* eduPersonTargetedID
-	* eduPersonPrincipalName
-	* pairwise-id
-	* subject-id
-	* openid
-	* facebook_targetedID
-	* twitter_targetedID
-	* windowslive_targetedID
-	* linkedin_targetedID
+  * eduPersonTargetedID
+  * eduPersonPrincipalName
+  * pairwise-id
+  * subject-id
+  * openid
+  * facebook_targetedID
+  * twitter_targetedID
+  * windowslive_targetedID
+  * linkedin_targetedID
 * `id_attribute`. A string to use as the name of the newly added attribute. Defaults to `smart_id`.
 * `add_authority`. A boolean to indicate whether or not to append the SAML AuthenticatingAuthority to the resulting identifier. This can be useful to indicate what SAML IdP was used, in case the original identifier is not scoped. When multiple values are in the AuthenticatingAuthority element, the last (closest to us) will be used. Defaults to `TRUE`.
 * `add_candidate`. A boolean to indicate whether or not to prepend the candidate attribute name to the resulting identifier. This can be useful to indicate the attribute originating the identifier. Defaults to `TRUE`.
@@ -42,12 +40,13 @@ Examples
 
 Without any configuration:
 
-	'authproc' => array(
-		50 => array(
-			'class' => 'smartattributes:SmartID'
-		),
-	),
-
+```php
+'authproc' => [
+    50 => [
+        'class' => 'smartattributes:SmartID'
+    ],
+],
+```
 
 This will add an attribute called `smart_id` with a value looking like, for example:
 
@@ -55,14 +54,16 @@ This will add an attribute called `smart_id` with a value looking like, for exam
 
 Custom configuration:
 
-	'authproc' => array(
-		50 => array(
-			'class' => 'smartattributes:SmartID',
-			'candidates' => array('eduPersonTargetedID', 'eduPersonPrincipalName'),
-			'id_attribute' => 'FooUniversityLocalID',
-			'add_authority' => FALSE,
-		),
-	),
+```php
+'authproc' => [
+    50 => [
+        'class' => 'smartattributes:SmartID',
+        'candidates' => ['eduPersonTargetedID', 'eduPersonPrincipalName'],
+        'id_attribute' => 'FooUniversityLocalID',
+        'add_authority' => FALSE,
+    ],
+],
+```
 
 This will add an attribute called `FooUniversityLocalID` with a value like:
 
@@ -70,15 +71,17 @@ This will add an attribute called `FooUniversityLocalID` with a value like:
 
 If you also want to remove the name of the originating attribute, you could configure it like this:
 
-	'authproc' => array(
-		50 => array(
-			'class' => 'smartattributes:SmartID',
-			'candidates' => array('eduPersonTargetedID', 'eduPersonPrincipalName'),
-			'id_attribute' => 'FooUniversityLocalID',
-			'add_authority' => FALSE,
-			'add_candidate' => FALSE,
-		),
-	),
+```php
+'authproc' => [
+    50 => [
+        'class' => 'smartattributes:SmartID',
+        'candidates' => ['eduPersonTargetedID', 'eduPersonPrincipalName'],
+        'id_attribute' => 'FooUniversityLocalID',
+        'add_authority' => FALSE,
+        'add_candidate' => FALSE,
+    ],
+],
+```
 
 Resulting in:
 

--- a/src/Auth/Process/SmartID.php
+++ b/src/Auth/Process/SmartID.php
@@ -117,9 +117,10 @@ class SmartID extends \SimpleSAML\Auth\ProcessingFilter
         $state = $request['saml:sp:State'];
         foreach ($this->candidates as $idCandidate) {
             if (isset($attributes[$idCandidate][0])) {
-                if (($this->add_authority) && (isset($state['saml:AuthenticatingAuthority'][0]))) {
+                if ($this->add_authority && count($state['saml:AuthenticatingAuthority']) > 0) {
+                    $authority = end($state['saml:AuthenticatingAuthority']);
                     return ($this->add_candidate ? $idCandidate . ':' : '') . $attributes[$idCandidate][0] . '!' .
-                        $state['saml:AuthenticatingAuthority'][0];
+                        $authority;
                 } else {
                     return ($this->add_candidate ? $idCandidate . ':' : '') . $attributes[$idCandidate][0];
                 }


### PR DESCRIPTION
In proxying scenarios, upstream proxies may add more elements to the chain of AuthenticatingAuthorities. When multiple elements are present, the one most recently added is at the end of the list (SAML core 3.4.1.5.1). This is the IdP closest to us. Other proxies could be added at any time after it, and this should not influence the outcome.

This may change ID's generated with the old code. However, I would consider those ID's to be already buggy. But it makes sense to list this as a potentially breaking change in the release notes.

Closes #2
Closes simplesamlphp/simplesamlphp#1431