### PR TITLE
Aassets version and correct path to saml:AuthenticatingAuthority 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
     "require": {
         "php": "^8.3",
 
-        "simplesamlphp/assert": "^1.9",
+        "simplesamlphp/assert": "^2.0",
         "simplesamlphp/composer-module-installer": "^1.5",
         "simplesamlphp/simplesamlphp": "^2.5@dev"
     },

--- a/src/Auth/Process/SmartID.php
+++ b/src/Auth/Process/SmartID.php
@@ -108,7 +108,7 @@ class SmartID extends \SimpleSAML\Auth\ProcessingFilter
 
     /**
      * @param array<mixed> $attributes
-     * @param array<mixed> $request
+     * @param array<mixed> $state
      * @return string
      * @throws \SimpleSAML\Error\Exception
      */

--- a/src/Auth/Process/SmartID.php
+++ b/src/Auth/Process/SmartID.php
@@ -112,9 +112,8 @@ class SmartID extends \SimpleSAML\Auth\ProcessingFilter
      * @return string
      * @throws \SimpleSAML\Error\Exception
      */
-    private function addID(array $attributes, array $request): string
+    private function addID(array $attributes, array $state): string
     {
-        $state = $request['saml:sp:State'];
         foreach ($this->candidates as $idCandidate) {
             if (isset($attributes[$idCandidate][0])) {
                 if ($this->add_authority && count($state['saml:AuthenticatingAuthority']) > 0) {


### PR DESCRIPTION
Tag 1.1.0 has a few issues with SSP 2.5.2 , the first is an incorrect value in composer.json, which leads to an error when the module is required by composer . Second one request array is changed, and saml:AuthenticatingAuthority attribute isn't under root saml:sp:State .